### PR TITLE
Add startup and liveness probes to tile server

### DIFF
--- a/helm/osm-machinery/templates/tile-server-deployment.yaml
+++ b/helm/osm-machinery/templates/tile-server-deployment.yaml
@@ -59,6 +59,21 @@ spec:
             - name: scripts-volume
               mountPath: /app/scripts
           command: [ "sh", "/app/scripts/tile-server-entrypoint.sh" ]
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            failureThreshold: 30
+            periodSeconds: 10
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
 
       volumes:
         - name: tmp


### PR DESCRIPTION
That way:
* POD will restart apache is oomkill-ed
* We can restart the server in a graceful way